### PR TITLE
Improve build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export default function (props: Props, context: BosContext) {
         </a>
       </p>
       <Widget
-        src="frol.near/widget/bos-component-ts-starter.components.subfolder.my-nested-component"
+        src="devgovgigs.near/widget/components.subfolder.my-nested-component"
         props={{ color: "green" }}
       />
     </>
@@ -40,19 +40,19 @@ export default function (props: Props, context: BosContext) {
 
 This is a preconfigured project that puts things together:
 
-* [sucrase](https://sucrase.io/) is the heart of this starter project that transpiles TSX syntax to JSX
-* [near-social-vm-types](https://www.npmjs.com/package/near-social-vm-types) defines BOS VM API as TypeScript types
-* [bos CLI](https://bos.cli.rs) helps to deploy local files all at once to [SocialDB](https://github.com/NearSocial/social-db) (use [`npm run deploy`](https://github.com/frol/bos-component-ts-starter/blob/beb7e6722c46dc53282c9e42b5388fe4ad16819e/package.json#L18))
-* [prettier](https://prettier.io/) helps to keep the code nicely formatted (use [`npm run fmt` and `npm run fmt:check`](https://github.com/frol/bos-component-ts-starter/blob/beb7e6722c46dc53282c9e42b5388fe4ad16819e/package.json#L14-L15))
+- [sucrase](https://sucrase.io/) is the heart of this starter project that transpiles TSX syntax to JSX
+- [near-social-vm-types](https://www.npmjs.com/package/near-social-vm-types) defines BOS VM API as TypeScript types
+- [bos CLI](https://bos.cli.rs) helps to deploy local files all at once to [SocialDB](https://github.com/NearSocial/social-db) (use [`npm run deploy`](https://github.com/frol/bos-component-ts-starter/blob/beb7e6722c46dc53282c9e42b5388fe4ad16819e/package.json#L18))
+- [prettier](https://prettier.io/) helps to keep the code nicely formatted (use [`npm run fmt` and `npm run fmt:check`](https://github.com/frol/bos-component-ts-starter/blob/beb7e6722c46dc53282c9e42b5388fe4ad16819e/package.json#L14-L15))
 
 You can also find several auxiliary files in this repo:
 
-* [`build.js`](https://github.com/frol/bos-component-ts-starter/blob/main/build.js) handles several useful features:
-  * [X]  automatically returns the `export default function` as BOS component, so you don't need to have a free-standing `return <MyComponent props={props} />` statement at the end of your file.
-  * [X]  mimics standard `import ... from ...` syntax for files saved in `src/includes/` folder (see how to use imports [here](https://github.com/frol/bos-component-ts-starter/blob/main/src/components/subfolder/my-nested-component.tsx))
-  * [X]  automatically adds license, author, and homepage link from package.json to the headers of each BOS component
-* [`tsconfig.json`](https://github.com/frol/bos-component-ts-starter/blob/main/tsconfig.json) is used by VS Code to properly resolve types and project structure
-* [`global.d.ts`](https://github.com/frol/bos-component-ts-starter/blob/main/global.d.ts) is used to inject types of `<Widget>` and `BosContext`, and ignore non-existing React dependency.
+- [`build.js`](https://github.com/frol/bos-component-ts-starter/blob/main/build.js) handles several useful features:
+  - [x] automatically returns the `export default function` as BOS component, so you don't need to have a free-standing `return <MyComponent props={props} />` statement at the end of your file.
+  - [x] mimics standard `import ... from ...` syntax for files saved in `src/includes/` folder (see how to use imports [here](https://github.com/frol/bos-component-ts-starter/blob/main/src/components/subfolder/my-nested-component.tsx))
+  - [x] automatically adds license, author, and homepage link from package.json to the headers of each BOS component
+- [`tsconfig.json`](https://github.com/frol/bos-component-ts-starter/blob/main/tsconfig.json) is used by VS Code to properly resolve types and project structure
+- [`global.d.ts`](https://github.com/frol/bos-component-ts-starter/blob/main/global.d.ts) is used to inject types of `<Widget>` and `BosContext`, and ignore non-existing React dependency.
 
 Putting all those pieces together, a fully working starter project in TypeScript was born.
 If you develop in VS Code, it should properly highlight issues with types now, and allow you to define your own types to ensure consistency of your code-base.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Learn about [BOS-LOADER](https://docs.near.org/bos/dev/bos-loader) more
 3. Run `yarn build`
 4. Then run `yarn dev`
 5. Open `https://near.org/<youraccount.near>/widget/<component name>` (case sensitive)
-   For example `https://near.org/devgovgigs.near/widget/bos-component-ts-starter.components.pages.homepage`
+   For example `https://near.org/dev.near/widget/components.pages.homepage`
 6. Make changes to the component's code. Repeate steps 2-5 to see the changes.
 
 ## How to Use

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export default function (props: Props, context: BosContext) {
         </a>
       </p>
       <Widget
-        src="devgovgigs.near/widget/components.subfolder.my-nested-component"
+        src="dev.near/widget/components.subfolder.my-nested-component"
         props={{ color: "green" }}
       />
     </>

--- a/build.js
+++ b/build.js
@@ -30,7 +30,7 @@ async function build() {
 
   await replaceInFiles({
     files: [`${transpiledPathPrefix}/**/*.jsx`],
-    from: /import .* from "@\/includes\/([^"]*)";/gms,
+    from: /import .* from "@\/includes\/([^"]*)";/gm,
     to: (_match, importPath) => {
       const importedFileContent = readFileSync(
         `${transpiledPathPrefix}/../includes/${importPath}.jsx`,

--- a/build.js
+++ b/build.js
@@ -5,20 +5,6 @@ import replaceInFiles from "replace-in-files";
 const transpiledPathPrefix = ".bos/transpiled/src";
 
 async function build() {
-  await replaceInFiles({
-    files: [`${transpiledPathPrefix}/**/*.jsx`],
-    from: /export\s+default\s+function[^(]*\((.*)/gms,
-    to: (_match, rest) =>
-      `function MainComponent(${rest}\nreturn MainComponent(props, context);`,
-  });
-
-  await replaceInFiles({
-    files: [`${transpiledPathPrefix}/**/*.jsx`],
-    from: /export /g,
-    // NOTE: Empty string is ignored, so we use a function workaround it
-    to: () => "",
-  });
-
   // WARNING: Don't allow "imports" in includes as this may lead to undefined
   // behavior as replacements are done in parallel and one file may be getting
   // replacements saved while the other file needs to include it, which ends up
@@ -27,6 +13,19 @@ async function build() {
     `${transpiledPathPrefix}/includes`,
     `${transpiledPathPrefix}/../includes`
   );
+
+  await replaceInFiles({
+    files: [`${transpiledPathPrefix}/**/*.jsx`],
+    from: /export\s+default\s+function[^(]*\((.*)/gms,
+    to: (_match, rest) =>
+      `function MainComponent(${rest}\nreturn MainComponent(props, context);`,
+  });
+
+  await replaceInFiles({
+    files: [`${transpiledPathPrefix}/../includes/**/*.jsx`],
+    from: /^export.*function/gm,
+    to: "function",
+  });
 
   await replaceInFiles({
     files: [`${transpiledPathPrefix}/**/*.jsx`],

--- a/build.js
+++ b/build.js
@@ -2,7 +2,7 @@ import { rename } from "fs/promises";
 import { readFileSync } from "fs";
 import replaceInFiles from "replace-in-files";
 
-const transpiledPathPrefix = ".bos/transpiled/src/npm_package_name";
+const transpiledPathPrefix = ".bos/transpiled/src";
 
 async function build() {
   await replaceInFiles({
@@ -49,11 +49,6 @@ async function build() {
     from: /^/m,
     to: `/*\nLicense: ${packageJson.license}\nAuthor: ${packageJson.author}\nHomepage: ${packageJson.homepage}\n*/\n`,
   });
-
-  await rename(
-    transpiledPathPrefix,
-    `${transpiledPathPrefix}/../${packageJson.name}`
-  );
 
   console.log("DONE");
 }

--- a/build.js
+++ b/build.js
@@ -1,6 +1,7 @@
 import { rename } from "fs/promises";
 import { readFileSync } from "fs";
 import replaceInFiles from "replace-in-files";
+import { colorize } from "colorize-node";
 import { relative } from "path";
 import { exit } from "process";
 
@@ -30,7 +31,9 @@ async function build() {
     to: (match, defaultFunctionName, _num, _text, filePath) => {
       const relativeFilePath = relative(".bos/transpiled", filePath);
       console.warn(
-        `Using default exports for utils functions isn't recommended as it may cause unexpected import issues - please replace "export default function ${defaultFunctionName}" with "export function ${defaultFunctionName}" in the "${relativeFilePath}" file`
+        colorize.yellow(
+          `Using default exports for utils functions isn't recommended as it may cause unexpected import issues - please replace "export default function ${defaultFunctionName}" with "export function ${defaultFunctionName}" in the "${relativeFilePath}" file`
+        )
       );
 
       return match;
@@ -47,7 +50,9 @@ async function build() {
     to: (match, _num, _text, filePath) => {
       const relativeFilePath = relative(".bos/transpiled", filePath);
       console.error(
-        `Exports aren't allowed as this may lead to undefined behavior - please remove '${match}' in the '${relativeFilePath}' file`
+        colorize.redBright(
+          `Exports aren't allowed as this may lead to undefined behavior - please remove '${match}' in the '${relativeFilePath}' file`
+        )
       );
 
       exit(1);
@@ -61,7 +66,9 @@ async function build() {
     to: (match, _num, _text, filePath) => {
       const relativeFilePath = relative(".bos/transpiled", filePath);
       console.error(
-        `Imports in includes aren't allowed as this may lead to undefined behavior - please remove "${match}" in the "${relativeFilePath}" file`
+        colorize.redBright(
+          `Imports in includes aren't allowed as this may lead to undefined behavior - please remove "${match}" in the "${relativeFilePath}" file`
+        )
       );
 
       exit(1);

--- a/build.js
+++ b/build.js
@@ -13,7 +13,7 @@ async function build() {
 
   await replaceInFiles({
     files: [`${transpiledPathPrefix}/**/*.jsx`],
-    from: /^export /,
+    from: /export /g,
     // NOTE: Empty string is ignored, so we use a function workaround it
     to: () => "",
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/react": "^18.2.21",
         "@typescript-eslint/eslint-plugin": "^6.5.0",
         "bos-cli": "^0.3.2",
+        "colorize-node": "^0.5.1",
         "eslint": "^8.48.0",
         "husky": "^8.0.0",
         "lint-staged": "^14.0.1",
@@ -1074,6 +1075,16 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/colorize-node": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/colorize-node/-/colorize-node-0.5.1.tgz",
+      "integrity": "sha512-NEiJgkr1bRpy7ZNiDGN3vYRSMwVHrgaRSYZPOIYDA5VpFXyp0o3ZH+ZuW5lLQ0O7d5Xooqcg7djXIfdtx6U4nw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.12.0",
+        "pnpm": ">=8.12.0"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
     "fmt:check": "prettier --check '**/*.{js,jsx,ts,tsx,json}'",
     "lint": "tsc --pretty --noEmit && eslint .",
     "dev": "~/.cargo/bin/bos-loader devgovgigs.near --path ./.bos/transpiled/src",
-    "prebuild": "npm run fmt && rimraf .bos/transpiled && mkdir -p .bos/transpiled/src",
-    "build": "sucrase ./src -d .bos/transpiled/src --transforms typescript,jsx --jsx-runtime preserve --disable-es-transforms --out-extension jsx && node ./build.js",
+    "prebuild": "rimraf .bos/transpiled && mkdir -p .bos/transpiled/src && npm run lint",
+    "build": "sucrase ./src -d .bos/transpiled/src --transforms typescript,jsx --jsx-runtime preserve --disable-es-transforms --out-extension jsx",
+    "postbuild": "npm run fmt && node ./build.js",
     "predeploy": "npm run build",
     "deploy": "cd .bos/transpiled && bos components deploy",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
     "fmt:check": "prettier --check '**/*.{js,jsx,ts,tsx,json}'",
     "lint": "tsc --pretty --noEmit && eslint .",
     "dev": "~/.cargo/bin/bos-loader devgovgigs.near --path ./.bos/transpiled/src",
-    "build": "npm run fmt && rimraf .bos/transpiled && mkdir -p .bos/transpiled/src && sucrase ./src -d .bos/transpiled/src/npm_package_name --transforms typescript,jsx --jsx-runtime preserve --disable-es-transforms --out-extension jsx && node ./build.js",
-    "deploy": "npm run build && cd .bos/transpiled && bos components deploy",
+    "prebuild": "npm run fmt && rimraf .bos/transpiled && mkdir -p .bos/transpiled/src",
+    "build": "sucrase ./src -d .bos/transpiled/src/npm_package_name --transforms typescript,jsx --jsx-runtime preserve --disable-es-transforms --out-extension jsx && node ./build.js",
+    "predeploy": "npm run build",
+    "deploy": "cd .bos/transpiled && bos components deploy",
     "prepare": "husky install"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint": "tsc --pretty --noEmit && eslint .",
     "dev": "~/.cargo/bin/bos-loader devgovgigs.near --path ./.bos/transpiled/src",
     "prebuild": "npm run fmt && rimraf .bos/transpiled && mkdir -p .bos/transpiled/src",
-    "build": "sucrase ./src -d .bos/transpiled/src/npm_package_name --transforms typescript,jsx --jsx-runtime preserve --disable-es-transforms --out-extension jsx && node ./build.js",
+    "build": "sucrase ./src -d .bos/transpiled/src --transforms typescript,jsx --jsx-runtime preserve --disable-es-transforms --out-extension jsx && node ./build.js",
     "predeploy": "npm run build",
     "deploy": "cd .bos/transpiled && bos components deploy",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "fmt": "prettier --write '**/*.{js,jsx,ts,tsx,json}'",
     "fmt:check": "prettier --check '**/*.{js,jsx,ts,tsx,json}'",
     "lint": "tsc --pretty --noEmit && eslint .",
-    "dev": "~/.cargo/bin/bos-loader devgovgigs.near --path ./.bos/transpiled/src",
+    "dev": "~/.cargo/bin/bos-loader dev.near --path ./.bos/transpiled/src",
     "prebuild": "rimraf .bos/transpiled && mkdir -p .bos/transpiled/src && npm run lint",
     "build": "sucrase ./src -d .bos/transpiled/src --transforms typescript,jsx --jsx-runtime preserve --disable-es-transforms --out-extension jsx",
     "postbuild": "npm run fmt && node ./build.js",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@types/react": "^18.2.21",
     "@typescript-eslint/eslint-plugin": "^6.5.0",
     "bos-cli": "^0.3.2",
+    "colorize-node": "^0.5.1",
     "eslint": "^8.48.0",
     "husky": "^8.0.0",
     "lint-staged": "^14.0.1",

--- a/src/components/pages/homepage.tsx
+++ b/src/components/pages/homepage.tsx
@@ -22,7 +22,7 @@ export default function (props: Props, context: BosContext) {
         </a>
       </p>
       <Widget
-        src="frol.near/widget/bos-component-ts-starter.components.subfolder.my-nested-component"
+        src="dev.near/widget/components.subfolder.my-nested-component"
         props={{ color: "green" }}
       />
     </>


### PR DESCRIPTION
* move transpiled files from `.bos/transpiled/repo_name` to `.bos/transpiled`
* fix regex to prevent errors from importing multiple functions from `includes` (fixes https://github.com/frol/bos-component-ts-starter/issues/6)
* fix regex to exclude `export default` constructions from `includes` (fixes https://github.com/frol/bos-component-ts-starter/issues/4)
* replace `frol.near` account with another one that is used as source for widgets
* use `dev.near` account as widgets source on local environment
* display developer-friendly warnings and errors to prevent common errors during build
* break down `build` script into smaller parts for readability
* update Readme according to the latest changes